### PR TITLE
[FLINK-30062][Connectors/HBase] ADDENDUM: Bundle the exact same dependencies as it was in core

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -20,5 +20,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/tools/releasing/shared" vcs="Git" />
   </component>
 </project>

--- a/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connector-hbase-1.4/pom.xml
@@ -51,12 +51,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hbase-base</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Table ecosystem -->
@@ -67,6 +61,11 @@ under the License.
 			<artifactId>flink-table-api-java-bridge</artifactId>
 			<scope>provided</scope>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
 		</dependency>
 
 		<!-- Tests -->
@@ -226,20 +225,8 @@ under the License.
 					<artifactId>commons-cli</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-compress</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -283,18 +270,6 @@ under the License.
 					<groupId>commons-cli</groupId>
 					<artifactId>commons-cli</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -318,10 +293,6 @@ under the License.
 				<exclusion>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.avro</groupId>
@@ -403,18 +374,6 @@ under the License.
 					<artifactId>commons-cli</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.javassist</groupId>
 					<artifactId>javassist</artifactId>
 				</exclusion>
@@ -442,18 +401,6 @@ under the License.
 				<exclusion>
 					<groupId>commons-cli</groupId>
 					<artifactId>commons-cli</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connector-hbase-2.2/pom.xml
@@ -153,6 +153,10 @@ under the License.
 					<artifactId>hadoop-hdfs</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>org.jruby.jcodings</groupId>
+					<artifactId>jcodings</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
 				</exclusion>
@@ -161,6 +165,11 @@ under the License.
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
 		</dependency>
 
 		<!-- Tests -->
@@ -252,10 +261,6 @@ under the License.
 				<exclusion>
 					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-compress</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.javassist</groupId>
@@ -373,24 +378,6 @@ under the License.
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.11.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.12.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<version>1.2</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>16.0.1</version>
@@ -406,12 +393,6 @@ under the License.
 				<groupId>org.apache.htrace</groupId>
 				<artifactId>htrace-core4</artifactId>
 				<version>4.2.0-incubating</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.jruby.jcodings</groupId>
-				<artifactId>jcodings</artifactId>
-				<version>1.0.18</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/flink-connector-hbase-base/pom.xml
+++ b/flink-connector-hbase-base/pom.xml
@@ -141,14 +141,6 @@ under the License.
 					<artifactId>hadoop-hdfs</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
 				</exclusion>

--- a/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-sql-connector-hbase-2.2/pom.xml
@@ -39,12 +39,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hbase-2.2</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.hbase</groupId>
-					<artifactId>hbase-client</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
  - io.netty:netty-all:4.1.70.Final
  - io.dropwizard.metrics:metrics-core:3.2.6
  - org.apache.commons:commons-crypto:1.0.0
- - org.apache.commons:commons-lang3:3.12.0
+ - org.apache.commons:commons-lang3:3.3.2
  - org.apache.hbase:hbase-client:2.2.3
  - org.apache.hbase:hbase-common:2.2.3
  - org.apache.hbase:hbase-protocol:2.2.3

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@ under the License.
 		<scala.version>2.12.7</scala.version>
 
 		<assertj.version>3.21.0</assertj.version>
+		<commons.codec.version>1.15</commons.codec.version>
+		<commons.io.version>2.11.0</commons.io.version>
+		<commons.lang3.version>3.3.2</commons.lang3.version>
+		<commons.logging.version>1.1.3</commons.logging.version>
 		<hadoop.version>2.8.5</hadoop.version>
 		<hbase1.version>1.4.3</hbase1.version>
 		<hbase2.version>2.2.3</hbase2.version>
@@ -200,10 +204,6 @@ under the License.
 						<artifactId>commons-cli</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId>commons-codec</groupId>
-						<artifactId>commons-codec</artifactId>
-					</exclusion>
-					<exclusion>
 						<groupId>commons-collections</groupId>
 						<artifactId>commons-collections</artifactId>
 					</exclusion>
@@ -214,10 +214,6 @@ under the License.
 					<exclusion>
 						<groupId>commons-lang</groupId>
 						<artifactId>commons-lang</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>org.apache.commons</groupId>
@@ -281,16 +277,8 @@ under the License.
 						<artifactId>commons-cli</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId>commons-codec</groupId>
-						<artifactId>commons-codec</artifactId>
-					</exclusion>
-					<exclusion>
 						<groupId>commons-io</groupId>
 						<artifactId>commons-io</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -321,16 +309,8 @@ under the License.
 						<artifactId>commons-io</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-					<exclusion>
 						<groupId>commons-cli</groupId>
 						<artifactId>commons-cli</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>commons-codec</groupId>
-						<artifactId>commons-codec</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>org.apache.commons</groupId>
@@ -380,6 +360,30 @@ under the License.
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
 				<version>${netty.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${commons.io.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>${commons.lang3.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>${commons.codec.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging</artifactId>
+				<version>${commons.logging.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Without this, we not package the HBase specific classes into the `flink-sql-connector-hbase-2.2` artifact.