### PR TITLE
[FLINK-31759][hbase] Using sql_connector_download_table shortcode for table document.

### DIFF
--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -38,7 +38,7 @@ HBase 连接器在 upsert 模式下运行，可以使用 DDL 中定义的主键�
 依赖
 ------------
 
-{{< sql_download_table "hbase" >}}
+{{< sql_connector_download_table "hbase" 3.0.0 >}}
 
 HBase 连接器不是二进制发行版的一部分，请查阅[这里]({{< ref "docs/dev/configuration/overview" >}})了解如何在集群运行中引用 HBase 连接器。
 

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -38,7 +38,7 @@ HBase always works in upsert mode for exchange changelog messages with the exter
 Dependencies
 ------------
 
-{{< sql_download_table "hbase" >}}
+{{< sql_connector_download_table "hbase" 3.0.0 >}}
 
 The HBase connector is not part of the binary distribution.
 See how to link with it for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/data/hbase.yml
+++ b/docs/data/hbase.yml
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variants:
+  - maven: flink-connector-hbase-1.4
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-1.4/$full_version/flink-sql-connector-hbase-1.4-$full_version.jar
+  - maven: flink-connector-hbase-2.2
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-2.2/$full_version/flink-sql-connector-hbase-2.2-$full_version.jar


### PR DESCRIPTION
This should also backports to v3.0 branch.