### PR TITLE
[FLINK-28013] Shade all netty dependencies in sql jar

### DIFF
--- a/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-sql-connector-hbase-1.4/pom.xml
@@ -81,7 +81,7 @@ under the License.
 									<include>commons-logging:commons-logging</include>
 									<include>commons-lang:commons-lang</include>
 									<include>commons-codec:commons-codec</include>
-									<include>io.netty:netty-all</include>
+									<include>io.netty:*</include>
 								</includes>
 								<excludes>
 									<exclude>org.apache.hbase:hbase-common:jar:tests</exclude>

--- a/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-sql-connector-hbase-2.2/pom.xml
@@ -80,7 +80,7 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 									<include>org.apache.commons:commons-crypto</include>
 									<include>org.apache.commons:commons-lang3</include>
-									<include>io.netty:netty-all</include>
+									<include>io.netty:*</include>
 									<include>io.dropwizard.metrics:metrics-core</include>
 								</includes>
 								<excludes>


### PR DESCRIPTION
Shade all netty dependencies to resolve `java.lang.NoClassDefFoundError: org/apache/flink/hbase/shaded/io/netty/channel/EventLoopGroup`.