### PR TITLE
Fix problem due to HBaseRowDataLookupFunction returned to reuse objects

### DIFF
--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
@@ -97,7 +97,7 @@ public class HBaseRowDataLookupFunction extends LookupFunction {
                 if (get != null) {
                     Result result = table.get(get);
                     if (!result.isEmpty()) {
-                        return Collections.singletonList(serde.convertToReusedRow(result));
+                        return Collections.singletonList(serde.convertToNewRow(result));
                     }
                 }
                 break;


### PR DESCRIPTION
HBaseRowDataLookupFunction.lookup中返回的结果是Collections.singletonList(serde.convertToNewRow(result))，这里默认都是用convertToNewRow方法，内部是在复用同一个对象，当开启了lookup.cache的时候，会导致缓存的结果只都是同一个对象，从而导致结果错乱，由于这里目前不能判断是否使用cache，因此只能默认使用convertToNewRow返回一个新对象来避免上面的情况