### PR TITLE
[FLINK-33206] Verify the existence of hbase table before read/write

### DIFF
--- a/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowDataInputFormat.java
+++ b/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowDataInputFormat.java
@@ -86,12 +86,11 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
     }
 
     private void connectToTable() throws IOException {
-        try {
-            connection = ConnectionFactory.createConnection(getHadoopConfiguration());
-            table = (HTable) connection.getTable(TableName.valueOf(tableName));
-        } catch (TableNotFoundException tnfe) {
-            LOG.error("The table " + tableName + " not found ", tnfe);
-            throw new RuntimeException("HBase table '" + tableName + "' not found.", tnfe);
+        connection = ConnectionFactory.createConnection(getHadoopConfiguration());
+        TableName name = TableName.valueOf(tableName);
+        if (!connection.getAdmin().tableExists(name)) {
+            throw new TableNotFoundException("HBase table '" + tableName + "' not found.");
         }
+        table = (HTable) connection.getTable(name);
     }
 }

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -21,6 +21,10 @@ package org.apache.flink.connector.hbase1;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.sink.HBaseSinkFunction;
+import org.apache.flink.connector.hbase.sink.RowDataToMutationConverter;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase1.source.AbstractTableInputFormat;
 import org.apache.flink.connector.hbase1.source.HBaseRowDataInputFormat;
@@ -31,6 +35,7 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -38,7 +43,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CollectionUtil;
 
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
@@ -52,6 +59,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -491,6 +499,46 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 
         inputFormat.close();
         assertNull(inputFormat.getConnection());
+    }
+
+    @Test
+    public void testTableInputFormatTableExistence() throws IOException {
+        HBaseTableSchema tableSchema = new HBaseTableSchema();
+        tableSchema.addColumn(FAMILY1, F1COL1, byte[].class);
+        AbstractTableInputFormat<?> inputFormat =
+                new HBaseRowDataInputFormat(getConf(), TEST_NOT_EXISTS_TABLE, tableSchema, "null");
+
+        assertThatThrownBy(() -> inputFormat.createInputSplits(1))
+                .isExactlyInstanceOf(TableNotFoundException.class);
+
+        inputFormat.close();
+        assertNull(inputFormat.getConnection());
+    }
+
+    @Test
+    public void testHBaseSinkFunctionTableExistence() throws Exception {
+        org.apache.hadoop.conf.Configuration hbaseConf =
+                HBaseConfigurationUtil.getHBaseConfiguration();
+        hbaseConf.set(HConstants.ZOOKEEPER_QUORUM, getZookeeperQuorum());
+        hbaseConf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/hbase");
+
+        HBaseTableSchema tableSchema = new HBaseTableSchema();
+        tableSchema.addColumn(FAMILY1, F1COL1, byte[].class);
+
+        HBaseSinkFunction<RowData> sinkFunction =
+                new HBaseSinkFunction<>(
+                        TEST_NOT_EXISTS_TABLE,
+                        hbaseConf,
+                        new RowDataToMutationConverter(tableSchema, "null", false),
+                        2 * 1024 * 1024,
+                        1000,
+                        1000);
+
+        assertThatThrownBy(() -> sinkFunction.open(new Configuration()))
+                .getRootCause()
+                .isExactlyInstanceOf(TableNotFoundException.class);
+
+        sinkFunction.close();
     }
 
     // -------------------------------------------------------------------------------------

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -44,6 +44,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
+    protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
     protected static final String ROW_KEY = "rowkey";
 

--- a/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowDataInputFormat.java
+++ b/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowDataInputFormat.java
@@ -85,16 +85,14 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
     }
 
     private void connectToTable() throws IOException {
-        try {
-            if (connection == null) {
-                connection = ConnectionFactory.createConnection(getHadoopConfiguration());
-            }
-            TableName name = TableName.valueOf(getTableName());
-            table = connection.getTable(name);
-            regionLocator = connection.getRegionLocator(name);
-        } catch (TableNotFoundException tnfe) {
-            LOG.error("The table " + tableName + " not found ", tnfe);
-            throw new RuntimeException("HBase table '" + tableName + "' not found.", tnfe);
+        if (connection == null) {
+            connection = ConnectionFactory.createConnection(getHadoopConfiguration());
         }
+        TableName name = TableName.valueOf(tableName);
+        if (!connection.getAdmin().tableExists(name)) {
+            throw new TableNotFoundException("HBase table '" + tableName + "' not found.");
+        }
+        table = connection.getTable(name);
+        regionLocator = connection.getRegionLocator(name);
     }
 }

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -44,6 +44,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
+    protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
     protected static final String ROW_KEY = "rowkey";
 

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
@@ -120,9 +120,14 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             if (null == connection) {
                 this.connection = ConnectionFactory.createConnection(config);
             }
+
+            TableName tableName = TableName.valueOf(hTableName);
+            if (!connection.getAdmin().tableExists(tableName)) {
+                throw new TableNotFoundException(tableName);
+            }
+
             // create a parameter instance, set the table name and custom listener reference.
-            BufferedMutatorParams params =
-                    new BufferedMutatorParams(TableName.valueOf(hTableName)).listener(this);
+            BufferedMutatorParams params = new BufferedMutatorParams(tableName).listener(this);
             if (bufferFlushMaxSizeInBytes > 0) {
                 params.writeBufferSize(bufferFlushMaxSizeInBytes);
             }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Verify the existence of hbase table when call `open` function.

## Brief change log

  - *verify the existence of hbase table when call `open` function in source and sink*

## Verifying this change

This change is already covered by existing tests, such as
  - *org.apache.flink.connector.hbase1.HBaseConnectorITCase#testTableInputFormatTableExistence*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testTableInputFormatTableExistence*
  - *org.apache.flink.connector.hbase1.HBaseConnectorITCase#testHBaseSinkFunctionTableExistence*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testHBaseSinkFunctionTableExistence*