### PR TITLE
[FLINK-33207] Return empty split when the hbase table is empty

### DIFF
--- a/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
+++ b/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
@@ -230,14 +230,7 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
             // Get the starting and ending row keys for every region in the currently open table
             final Pair<byte[][], byte[][]> keys = table.getRegionLocator().getStartEndKeys();
             if (keys == null || keys.getFirst() == null || keys.getFirst().length == 0) {
-                LOG.warn(
-                        "Unexpected region keys: {} appeared in HBase table: {}, all region information are: {}.",
-                        keys,
-                        table,
-                        table.getRegionLocator().getAllRegionLocations());
-                throw new IOException(
-                        "HBase Table expects at least one region in scan,"
-                                + " please check the HBase table status in HBase cluster");
+                return new TableInputSplit[] {};
             }
             final byte[] startRow = scan.getStartRow();
             final byte[] stopRow = scan.getStopRow();

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -117,6 +117,31 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
+    public void testTableSourceEmptyTableScan() {
+        TableEnvironment tEnv = TableEnvironment.create(batchSettings);
+
+        tEnv.executeSql(
+                "CREATE TABLE hTable ("
+                        + " family1 ROW<col1 INT>,"
+                        + " rowkey INT,"
+                        + " PRIMARY KEY (rowkey) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-1.4',"
+                        + " 'table-name' = '"
+                        + TEST_EMPTY_TABLE
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT rowkey, h.family1.col1 FROM hTable AS h");
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
     public void testTableSourceProjection() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -44,6 +44,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
+    protected static final String TEST_EMPTY_TABLE = "testEmptyTable";
     protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
     protected static final String ROW_KEY = "rowkey";
@@ -95,6 +96,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable2();
         createHBaseTable3();
         createHBaseTable4();
+        createEmptyHBaseTable();
     }
 
     private static void createHBaseTable1() throws IOException {
@@ -239,6 +241,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         // create a table
         byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
         TableName tableName = TableName.valueOf(TEST_TABLE_4);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createEmptyHBaseTable() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_EMPTY_TABLE);
         createTable(tableName, families, SPLIT_KEYS);
     }
 

--- a/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
+++ b/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
@@ -230,14 +230,7 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
             // Get the starting and ending row keys for every region in the currently open table
             final Pair<byte[][], byte[][]> keys = regionLocator.getStartEndKeys();
             if (keys == null || keys.getFirst() == null || keys.getFirst().length == 0) {
-                LOG.warn(
-                        "Unexpected region keys: {} appeared in HBase table: {}, all region information are: {}.",
-                        keys,
-                        table,
-                        regionLocator.getAllRegionLocations());
-                throw new IOException(
-                        "HBase Table expects at least one region in scan,"
-                                + " please check the HBase table status in HBase cluster");
+                return new TableInputSplit[] {};
             }
             final byte[] startRow = scan.getStartRow();
             final byte[] stopRow = scan.getStopRow();

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -131,6 +131,31 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
+    public void testTableSourceEmptyTableScan() {
+        TableEnvironment tEnv = TableEnvironment.create(batchSettings);
+
+        tEnv.executeSql(
+                "CREATE TABLE hTable ("
+                        + " family1 ROW<col1 INT>,"
+                        + " rowkey INT,"
+                        + " PRIMARY KEY (rowkey) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-2.2',"
+                        + " 'table-name' = '"
+                        + TEST_EMPTY_TABLE
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT rowkey, h.family1.col1 FROM hTable AS h");
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
     public void testTableSourceProjection() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -44,6 +44,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
+    protected static final String TEST_EMPTY_TABLE = "testEmptyTable";
     protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
     protected static final String ROW_KEY = "rowkey";
@@ -95,6 +96,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable2();
         createHBaseTable3();
         createHBaseTable4();
+        createEmptyHBaseTable();
     }
 
     private static void createHBaseTable1() throws IOException {
@@ -239,6 +241,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         // create a table
         byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
         TableName tableName = TableName.valueOf(TEST_TABLE_4);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createEmptyHBaseTable() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_EMPTY_TABLE);
         createTable(tableName, families, SPLIT_KEYS);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

If the hbase table is empty, it will throw an error when `createInputSplits`, we should return empty split instead.

## Brief change log

  - *return empty split instead of throw an error when the hbase table is empty*

## Verifying this change

This change is already covered by existing tests, such as
  - *org.apache.flink.connector.hbase1.HBaseConnectorITCase#testTableSourceEmptyTableScan*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testTableSourceEmptyTableScan*