### PR TITLE
[hotfix] Exclude http-only available Maven dependencies and include 1.18-SNAPSHOT in PR tests

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.16.2, 1.17.1]
+        flink: [1.16.2, 1.17.1, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connector-hbase-1.4/pom.xml
@@ -345,6 +345,12 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-minicluster</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connector-hbase-2.2/pom.xml
@@ -87,6 +87,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -358,6 +362,12 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-minicluster</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-connector-hbase-base/pom.xml
+++ b/flink-connector-hbase-base/pom.xml
@@ -74,6 +74,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-connector-hbase-e2e-tests/pom.xml
+++ b/flink-connector-hbase-e2e-tests/pom.xml
@@ -76,6 +76,12 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -131,6 +137,12 @@ under the License.
 			<artifactId>hadoop-minicluster</artifactId>
 			<version>${hadoop.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,10 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>net.minidev</groupId>
+						<artifactId>json-smart</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 
@@ -348,6 +352,10 @@ under the License.
 					<exclusion>
 						<groupId>org.javassist</groupId>
 						<artifactId>javassist</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>net.minidev</groupId>
+						<artifactId>json-smart</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,12 @@ under the License.
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.23.0</version>
+			</dependency>
+
+			<dependency>
 				<groupId>com.fasterxml.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>


### PR DESCRIPTION
ea12f5ef97e62d8869cb94c6b5c7d9d8efc4cbb3 is to exclude json-smart, which throws warnings when running a Maven build since it's only available in a http repository

420fb2ab5027bdf0d7aaacc7f1f9e22b93e64f00 is to also include 1.18-SNAPSHOT in PR tests, since only PR tests actually test dependency convergence