### PR TITLE
[hotfix] Rely on org.apache.flink's surefire configuration

### DIFF
--- a/flink-connector-hbase-e2e-tests/pom.xml
+++ b/flink-connector-hbase-e2e-tests/pom.xml
@@ -151,39 +151,6 @@ under the License.
 		</dependency>
 	</dependencies>
 
-	<profiles>
-		<profile>
-			<id>run-end-to-end-tests</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>end-to-end-tests</id>
-								<phase>integration-test</phase>
-								<goals>
-									<goal>test</goal>
-								</goals>
-								<configuration>
-									<includes>
-										<include>**/*.*</include>
-									</includes>
-									<!-- E2E tests must not access flink-dist concurrently. -->
-									<forkCount>1</forkCount>
-									<systemPropertyVariables>
-										<moduleDir>${project.basedir}</moduleDir>
-									</systemPropertyVariables>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
The issue with current configuration is that after switching to flink-connector-parent at https://github.com/apache/flink-connector-hbase/pull/18 it started inheriting flink-connector-parent's surefire configuration for integration tests. 
As a result it starts running integration tests twice which also became a reason for failures like https://github.com/apache/flink-connector-hbase/actions/runs/6505430904/job/17669031804#step:13:13163