### PR TITLE
[FLINK-33304] Introduce the DeduplicatedMutator to resolve the mutation write conflict problem

### DIFF
--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -29,10 +29,13 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.hadoop.hbase.TableName;
@@ -41,11 +44,14 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -278,6 +284,59 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                         + "+I[8, 80, null, 800, 8.08, true, Welt-8]\n";
 
         TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @Test
+    public void testTableSinkWithChangelog() throws Exception {
+        StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+
+        // register values table for source
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.ofKind(RowKind.INSERT, 1, Row.of("Hello1")),
+                                Row.ofKind(RowKind.DELETE, 1, Row.of("Hello2")),
+                                Row.ofKind(RowKind.INSERT, 2, Row.of("Hello1")),
+                                Row.ofKind(RowKind.INSERT, 2, Row.of("Hello2")),
+                                Row.ofKind(RowKind.INSERT, 2, Row.of("Hello3")),
+                                Row.ofKind(RowKind.DELETE, 2, Row.of("Hello3")),
+                                Row.ofKind(RowKind.INSERT, 1, Row.of("Hello3"))));
+        tEnv.executeSql(
+                "CREATE TABLE source_table ("
+                        + " rowkey INT,"
+                        + " family1 ROW<name STRING>,"
+                        + " PRIMARY KEY (rowkey) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'values',"
+                        + " 'data-id' = '"
+                        + dataId
+                        + "',"
+                        + " 'changelog-mode'='I,UA,UB,D'"
+                        + ")");
+
+        // register HBase table for sink
+        tEnv.executeSql(
+                "CREATE TABLE sink_table ("
+                        + " rowkey INT,"
+                        + " family1 ROW<name STRING>,"
+                        + " PRIMARY KEY (rowkey) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-1.4',"
+                        + " 'table-name' = '"
+                        + TEST_TABLE_4
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        tEnv.executeSql("INSERT INTO sink_table SELECT * FROM source_table").await();
+
+        TableResult result = tEnv.executeSql("SELECT * FROM sink_table");
+
+        List<Row> actual = CollectionUtil.iteratorToList(result.collect());
+        assertThat(actual).isEqualTo(Collections.singletonList(Row.of(1, Row.of("Hello3"))));
     }
 
     @Test

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -43,6 +43,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_1 = "testTable1";
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
+    protected static final String TEST_TABLE_4 = "testTable4";
 
     protected static final String ROW_KEY = "rowkey";
 
@@ -92,6 +93,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable1();
         createHBaseTable2();
         createHBaseTable3();
+        createHBaseTable4();
     }
 
     private static void createHBaseTable1() throws IOException {
@@ -229,6 +231,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
                     Bytes.toBytes(FAMILY4),
                 };
         TableName tableName = TableName.valueOf(TEST_TABLE_3);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createHBaseTable4() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_TABLE_4);
         createTable(tableName, families, SPLIT_KEYS);
     }
 

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -43,6 +43,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_1 = "testTable1";
     protected static final String TEST_TABLE_2 = "testTable2";
     protected static final String TEST_TABLE_3 = "testTable3";
+    protected static final String TEST_TABLE_4 = "testTable4";
 
     protected static final String ROW_KEY = "rowkey";
 
@@ -92,6 +93,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable1();
         createHBaseTable2();
         createHBaseTable3();
+        createHBaseTable4();
     }
 
     private static void createHBaseTable1() throws IOException {
@@ -229,6 +231,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
                     Bytes.toBytes(FAMILY4),
                 };
         TableName tableName = TableName.valueOf(TEST_TABLE_3);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createHBaseTable4() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_TABLE_4);
         createTable(tableName, families, SPLIT_KEYS);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Current we put the `Mutation` into `BufferedMutator` directly, when `Mutation` have a `Delete` followed by `Put` to same column family or columns or rows, only the `Delete` is happening while the `Put` is ignored so atomicity of `Mutation` is broken for such cases.

See https://issues.apache.org/jira/browse/HBASE-8626.

## Brief change log

  - *add `mutationBuffer` to resolve the mutation write conflicts problem*

## Verifying this change

This change is already covered by existing tests, such as
  - *org.apache.flink.connector.hbase1.HBaseConnectorITCase#testTableSinkWithChangelog*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testTableSinkWithChangelog*

