### PR TITLE
[FLINK-33542] Update tests to JUnit5

### DIFF
--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,19 +61,16 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /** IT cases for HBase connector (source and sink). */
-public class HBaseConnectorITCase extends HBaseTestBase {
+class HBaseConnectorITCase extends HBaseTestBase {
 
     // -------------------------------------------------------------------------------------
     // HBaseTableSource tests
     // -------------------------------------------------------------------------------------
 
     @Test
-    public void testTableSourceFullScan() {
+    void testTableSourceFullScan() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
         tEnv.executeSql(
                 "CREATE TABLE hTable ("
@@ -118,7 +115,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSourceEmptyTableScan() {
+    void testTableSourceEmptyTableScan() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 
         tEnv.executeSql(
@@ -143,7 +140,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSourceProjection() {
+    void testTableSourceProjection() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 
         tEnv.executeSql(
@@ -187,7 +184,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSourceFieldOrder() {
+    void testTableSourceFieldOrder() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 
         tEnv.executeSql(
@@ -223,7 +220,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSourceReadAsByteArray() {
+    void testTableSourceReadAsByteArray() {
         TableEnvironment tEnv = TableEnvironment.create(batchSettings);
 
         tEnv.executeSql(
@@ -265,7 +262,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSink() throws Exception {
+    void testTableSink() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -321,7 +318,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSinkWithChangelog() throws Exception {
+    void testTableSinkWithChangelog() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -492,7 +489,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSourceSinkWithDDL() throws Exception {
+    void testTableSourceSinkWithDDL() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -559,11 +556,11 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                 "+I[7, 70, Hello-7, 700, 7.07, false, Welt-7, 2019-08-19T19:30, 2019-08-19, 19:30, 12345678.0007]");
         expected.add(
                 "+I[8, 80, null, 800, 8.08, true, Welt-8, 2019-08-19T19:40, 2019-08-19, 19:40, 12345678.0008]");
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    public void testHBaseLookupTableSource() {
+    void testHBaseLookupTableSource() {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -628,25 +625,26 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         expected.add(
                 "+I[3, 3, 30, Hello-3, 300, 3.03, false, Welt-3, 2019-08-18T19:02, 2019-08-18, 19:02, 12345678.0003]");
 
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    public void testTableInputFormatOpenClose() throws IOException {
+    void testTableInputFormatOpenClose() throws IOException {
         HBaseTableSchema tableSchema = new HBaseTableSchema();
         tableSchema.addColumn(FAMILY1, F1COL1, byte[].class);
         AbstractTableInputFormat<?> inputFormat =
                 new HBaseRowDataInputFormat(getConf(), TEST_TABLE_1, tableSchema, "null");
         inputFormat.open(inputFormat.createInputSplits(1)[0]);
-        assertNotNull(inputFormat.getConnection());
-        assertNotNull(inputFormat.getConnection().getTable(TableName.valueOf(TEST_TABLE_1)));
+        assertThat(inputFormat.getConnection()).isNotNull();
+        assertThat(inputFormat.getConnection().getTable(TableName.valueOf(TEST_TABLE_1)))
+                .isNotNull();
 
         inputFormat.close();
-        assertNull(inputFormat.getConnection());
+        assertThat(inputFormat.getConnection()).isNull();
     }
 
     @Test
-    public void testTableInputFormatTableExistence() throws IOException {
+    void testTableInputFormatTableExistence() throws IOException {
         HBaseTableSchema tableSchema = new HBaseTableSchema();
         tableSchema.addColumn(FAMILY1, F1COL1, byte[].class);
         AbstractTableInputFormat<?> inputFormat =
@@ -656,11 +654,11 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                 .isExactlyInstanceOf(TableNotFoundException.class);
 
         inputFormat.close();
-        assertNull(inputFormat.getConnection());
+        assertThat(inputFormat.getConnection()).isNull();
     }
 
     @Test
-    public void testHBaseSinkFunctionTableExistence() throws Exception {
+    void testHBaseSinkFunctionTableExistence() throws Exception {
         org.apache.hadoop.conf.Configuration hbaseConf =
                 HBaseConfigurationUtil.getHBaseConfiguration();
         hbaseConf.set(HConstants.ZOOKEEPER_QUORUM, getZookeeperQuorum());

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -371,7 +371,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSinkWithTimestampMetadata() throws Exception {
+    void testTableSinkWithTimestampMetadata() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -421,7 +421,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSinkWithTTLMetadata() throws Exception {
+    void testTableSinkWithTTLMetadata() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
@@ -129,7 +129,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testLookupOptions() {
+    void testLookupOptions() {
         ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
         Map<String, String> options = getAllOptions();
         options.put("lookup.cache", "PARTIAL");
@@ -155,7 +155,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkFactory() {
+    void testTableSinkFactory() {
         ResolvedSchema schema =
                 ResolvedSchema.of(
                         Column.physical(ROWKEY, STRING()),
@@ -215,7 +215,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBufferFlushOptions() {
+    void testBufferFlushOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.buffer-flush.max-size", "10mb");
         options.put("sink.buffer-flush.max-rows", "100");
@@ -235,7 +235,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testSinkIgnoreNullValueOptions() {
+    void testSinkIgnoreNullValueOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.ignore-null-value", "true");
 
@@ -247,7 +247,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testParallelismOptions() {
+    void testParallelismOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.parallelism", "2");
 
@@ -263,7 +263,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testDisabledBufferFlushOptions() {
+    void testDisabledBufferFlushOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.buffer-flush.max-size", "0");
         options.put("sink.buffer-flush.max-rows", "0");
@@ -283,7 +283,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testUnknownOption() {
+    void testUnknownOption() {
         Map<String, String> options = getAllOptions();
         options.put("sink.unknown.key", "unknown-value");
         ResolvedSchema schema =
@@ -302,7 +302,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTypeWithUnsupportedPrecision() {
+    void testTypeWithUnsupportedPrecision() {
         Map<String, String> options = getAllOptions();
         // test unsupported timestamp precision
         ResolvedSchema wrongTs =

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -82,12 +82,12 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected EnvironmentSettings streamSettings;
     protected EnvironmentSettings batchSettings;
 
-    @BeforeClass
+    @BeforeAll
     public static void activateHBaseCluster() throws IOException {
         prepareTables();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         this.streamSettings = EnvironmentSettings.inStreamingMode();
         this.batchSettings = EnvironmentSettings.inBatchMode();

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -400,7 +400,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSinkWithTimestampMetadata() throws Exception {
+    void testTableSinkWithTimestampMetadata() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
@@ -450,7 +450,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
-    public void testTableSinkWithTTLMetadata() throws Exception {
+    void testTableSinkWithTTLMetadata() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase2.source.AbstractTableInputFormat;
 import org.apache.flink.connector.hbase2.source.HBaseRowDataInputFormat;
 import org.apache.flink.connector.hbase2.util.HBaseTestBase;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
@@ -39,7 +38,6 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
-import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -50,7 +48,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,13 +67,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT cases for HBase connector (including source and sink). */
 class HBaseConnectorITCase extends HBaseTestBase {
-
-    @RegisterExtension
-    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
-            new MiniClusterExtension(
-                    new MiniClusterResourceConfiguration.Builder()
-                            .setConfiguration(new Configuration())
-                            .build());
 
     // -------------------------------------------------------------------------------------
     // HBaseTableSource tests

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
@@ -311,7 +311,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testUnknownOption() {
+    void testUnknownOption() {
         Map<String, String> options = getAllOptions();
         options.put("sink.unknown.key", "unknown-value");
         ResolvedSchema schema =
@@ -330,7 +330,7 @@ class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTypeWithUnsupportedPrecision() {
+    void testTypeWithUnsupportedPrecision() {
         Map<String, String> options = getAllOptions();
         // test unsupported timestamp precision
         ResolvedSchema wrongTs =

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase2.sink.HBaseDynamicTableSink;
 import org.apache.flink.connector.hbase2.source.HBaseDynamicTableSource;
 import org.apache.flink.connector.hbase2.source.HBaseRowDataAsyncLookupFunction;
+import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -39,19 +40,14 @@ import org.apache.flink.table.functions.AsyncLookupFunction;
 import org.apache.flink.table.functions.LookupFunction;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.hadoop.hbase.HConstants;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
@@ -67,13 +63,10 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit test for {@link HBase2DynamicTableFactory}. */
-public class HBaseDynamicTableFactoryTest {
+class HBaseDynamicTableFactoryTest {
 
     private static final String FAMILY1 = "f1";
     private static final String FAMILY2 = "f2";
@@ -85,11 +78,8 @@ public class HBaseDynamicTableFactoryTest {
     private static final String COL4 = "c4";
     private static final String ROWKEY = "rowkey";
 
-    @Rule public final ExpectedException thrown = ExpectedException.none();
-
-    @SuppressWarnings("rawtypes")
     @Test
-    public void testTableSourceFactory() {
+    void testTableSourceFactory() {
         ResolvedSchema schema =
                 ResolvedSchema.of(
                         Column.physical(FAMILY1, ROW(FIELD(COL1, INT()))),
@@ -110,44 +100,39 @@ public class HBaseDynamicTableFactoryTest {
                                         FIELD(COL4, TIME()))));
 
         DynamicTableSource source = createTableSource(schema, getAllOptions());
-        assertTrue(source instanceof HBaseDynamicTableSource);
+        assertThat(source).isInstanceOf(HBaseDynamicTableSource.class);
         HBaseDynamicTableSource hbaseSource = (HBaseDynamicTableSource) source;
 
         int[][] lookupKey = {{2}};
         LookupTableSource.LookupRuntimeProvider lookupProvider =
                 hbaseSource.getLookupRuntimeProvider(new LookupRuntimeProviderContext(lookupKey));
-        assertTrue(lookupProvider instanceof LookupFunctionProvider);
+        assertThat(lookupProvider).isInstanceOf(LookupFunctionProvider.class);
 
         LookupFunction tableFunction =
                 ((LookupFunctionProvider) lookupProvider).createLookupFunction();
-        assertTrue(tableFunction instanceof HBaseRowDataLookupFunction);
-        assertEquals(
-                "testHBastTable", ((HBaseRowDataLookupFunction) tableFunction).getHTableName());
+        assertThat(tableFunction).isInstanceOf(HBaseRowDataLookupFunction.class);
+        assertThat(((HBaseRowDataLookupFunction) tableFunction).getHTableName())
+                .isEqualTo("testHBastTable");
 
         HBaseTableSchema hbaseSchema = hbaseSource.getHBaseTableSchema();
-        assertEquals(2, hbaseSchema.getRowKeyIndex());
-        assertEquals(Optional.of(Types.LONG), hbaseSchema.getRowKeyTypeInfo());
+        assertThat(hbaseSchema.getRowKeyIndex()).isEqualTo(2);
+        assertThat(hbaseSchema.getRowKeyTypeInfo()).contains(Types.LONG);
 
-        assertArrayEquals(new String[] {"f1", "f2", "f3", "f4"}, hbaseSchema.getFamilyNames());
-        assertArrayEquals(new String[] {"c1"}, hbaseSchema.getQualifierNames("f1"));
-        assertArrayEquals(new String[] {"c1", "c2"}, hbaseSchema.getQualifierNames("f2"));
-        assertArrayEquals(new String[] {"c1", "c2", "c3"}, hbaseSchema.getQualifierNames("f3"));
-        assertArrayEquals(
-                new String[] {"c1", "c2", "c3", "c4"}, hbaseSchema.getQualifierNames("f4"));
-
-        assertArrayEquals(new DataType[] {INT()}, hbaseSchema.getQualifierDataTypes("f1"));
-        assertArrayEquals(
-                new DataType[] {INT(), BIGINT()}, hbaseSchema.getQualifierDataTypes("f2"));
-        assertArrayEquals(
-                new DataType[] {DOUBLE(), BOOLEAN(), STRING()},
-                hbaseSchema.getQualifierDataTypes("f3"));
-        assertArrayEquals(
-                new DataType[] {DECIMAL(10, 3), TIMESTAMP(3), DATE(), TIME()},
-                hbaseSchema.getQualifierDataTypes("f4"));
+        assertThat(hbaseSchema.getFamilyNames()).containsExactly("f1", "f2", "f3", "f4");
+        assertThat(hbaseSchema.getQualifierNames("f1")).containsExactly("c1");
+        assertThat(hbaseSchema.getQualifierNames("f2")).containsExactly("c1", "c2");
+        assertThat(hbaseSchema.getQualifierNames("f3")).containsExactly("c1", "c2", "c3");
+        assertThat(hbaseSchema.getQualifierNames("f4")).containsExactly("c1", "c2", "c3", "c4");
+        assertThat(hbaseSchema.getQualifierDataTypes("f1")).containsExactly(INT());
+        assertThat(hbaseSchema.getQualifierDataTypes("f2")).containsExactly(INT(), BIGINT());
+        assertThat(hbaseSchema.getQualifierDataTypes("f3"))
+                .containsExactly(DOUBLE(), BOOLEAN(), STRING());
+        assertThat(hbaseSchema.getQualifierDataTypes("f4"))
+                .containsExactly(DECIMAL(10, 3), TIMESTAMP(3), DATE(), TIME());
     }
 
     @Test
-    public void testLookupOptions() {
+    void testLookupOptions() {
         ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
         Map<String, String> options = getAllOptions();
         options.put("lookup.cache", "PARTIAL");
@@ -173,7 +158,7 @@ public class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkFactory() {
+    void testTableSinkFactory() {
         ResolvedSchema schema =
                 ResolvedSchema.of(
                         Column.physical(ROWKEY, STRING()),
@@ -190,29 +175,23 @@ public class HBaseDynamicTableFactoryTest {
                                         FIELD(COL4, TIME()))));
 
         DynamicTableSink sink = createTableSink(schema, getAllOptions());
-        assertTrue(sink instanceof HBaseDynamicTableSink);
+        assertThat(sink).isInstanceOf(HBaseDynamicTableSink.class);
         HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
 
         HBaseTableSchema hbaseSchema = hbaseSink.getHBaseTableSchema();
-        assertEquals(0, hbaseSchema.getRowKeyIndex());
-        assertEquals(Optional.of(STRING()), hbaseSchema.getRowKeyDataType());
+        assertThat(hbaseSchema.getRowKeyIndex()).isZero();
+        assertThat(hbaseSchema.getRowKeyDataType()).contains(STRING());
 
-        assertArrayEquals(new String[] {"f1", "f2", "f3", "f4"}, hbaseSchema.getFamilyNames());
-        assertArrayEquals(new String[] {"c1", "c2"}, hbaseSchema.getQualifierNames("f1"));
-        assertArrayEquals(new String[] {"c1", "c3"}, hbaseSchema.getQualifierNames("f2"));
-        assertArrayEquals(new String[] {"c2", "c3"}, hbaseSchema.getQualifierNames("f3"));
-        assertArrayEquals(
-                new String[] {"c1", "c2", "c3", "c4"}, hbaseSchema.getQualifierNames("f4"));
-
-        assertArrayEquals(
-                new DataType[] {DOUBLE(), INT()}, hbaseSchema.getQualifierDataTypes("f1"));
-        assertArrayEquals(
-                new DataType[] {INT(), BIGINT()}, hbaseSchema.getQualifierDataTypes("f2"));
-        assertArrayEquals(
-                new DataType[] {BOOLEAN(), STRING()}, hbaseSchema.getQualifierDataTypes("f3"));
-        assertArrayEquals(
-                new DataType[] {DECIMAL(10, 3), TIMESTAMP(3), DATE(), TIME()},
-                hbaseSchema.getQualifierDataTypes("f4"));
+        assertThat(hbaseSchema.getFamilyNames()).containsExactly("f1", "f2", "f3", "f4");
+        assertThat(hbaseSchema.getQualifierNames("f1")).containsExactly("c1", "c2");
+        assertThat(hbaseSchema.getQualifierNames("f2")).containsExactly("c1", "c3");
+        assertThat(hbaseSchema.getQualifierNames("f3")).containsExactly("c2", "c3");
+        assertThat(hbaseSchema.getQualifierNames("f4")).containsExactly("c1", "c2", "c3", "c4");
+        assertThat(hbaseSchema.getQualifierDataTypes("f1")).containsExactly(DOUBLE(), INT());
+        assertThat(hbaseSchema.getQualifierDataTypes("f2")).containsExactly(INT(), BIGINT());
+        assertThat(hbaseSchema.getQualifierDataTypes("f3")).containsExactly(BOOLEAN(), STRING());
+        assertThat(hbaseSchema.getQualifierDataTypes("f4"))
+                .containsExactly(DECIMAL(10, 3), TIMESTAMP(3), DATE(), TIME());
 
         // verify hadoop Configuration
         org.apache.hadoop.conf.Configuration expectedConfiguration =
@@ -223,12 +202,11 @@ public class HBaseDynamicTableFactoryTest {
 
         org.apache.hadoop.conf.Configuration actualConfiguration = hbaseSink.getConfiguration();
 
-        assertEquals(
-                IteratorUtils.toList(expectedConfiguration.iterator()),
-                IteratorUtils.toList(actualConfiguration.iterator()));
+        assertThat(IteratorUtils.toList(actualConfiguration.iterator()))
+                .isEqualTo(IteratorUtils.toList(expectedConfiguration.iterator()));
 
         // verify tableName
-        assertEquals("testHBastTable", hbaseSink.getTableName());
+        assertThat(hbaseSink.getTableName()).isEqualTo("testHBastTable");
 
         HBaseWriteOptions expectedWriteOptions =
                 HBaseWriteOptions.builder()
@@ -237,11 +215,11 @@ public class HBaseDynamicTableFactoryTest {
                         .setBufferFlushMaxSizeInBytes(2 * 1024 * 1024)
                         .build();
         HBaseWriteOptions actualWriteOptions = hbaseSink.getWriteOptions();
-        assertEquals(expectedWriteOptions, actualWriteOptions);
+        assertThat(actualWriteOptions).isEqualTo(expectedWriteOptions);
     }
 
     @Test
-    public void testBufferFlushOptions() {
+    void testBufferFlushOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.buffer-flush.max-size", "10mb");
         options.put("sink.buffer-flush.max-rows", "100");
@@ -257,11 +235,11 @@ public class HBaseDynamicTableFactoryTest {
                         .setBufferFlushMaxSizeInBytes(10 * 1024 * 1024)
                         .build();
         HBaseWriteOptions actual = ((HBaseDynamicTableSink) sink).getWriteOptions();
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void testSinkIgnoreNullValueOptions() {
+    void testSinkIgnoreNullValueOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.ignore-null-value", "true");
 
@@ -273,23 +251,23 @@ public class HBaseDynamicTableFactoryTest {
     }
 
     @Test
-    public void testParallelismOptions() {
+    void testParallelismOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.parallelism", "2");
 
         ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
 
         DynamicTableSink sink = createTableSink(schema, options);
-        assertTrue(sink instanceof HBaseDynamicTableSink);
+        assertThat(sink).isInstanceOf(HBaseDynamicTableSink.class);
         HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
         SinkFunctionProvider provider =
                 (SinkFunctionProvider)
                         hbaseSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
-        assertEquals(2, (long) provider.getParallelism().get());
+        assertThat(provider.getParallelism()).contains(2);
     }
 
     @Test
-    public void testLookupAsync() {
+    void testLookupAsync() {
         Map<String, String> options = getAllOptions();
         options.put("lookup.async", "true");
         ResolvedSchema schema =
@@ -297,24 +275,23 @@ public class HBaseDynamicTableFactoryTest {
                         Column.physical(ROWKEY, STRING()),
                         Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))));
         DynamicTableSource source = createTableSource(schema, options);
-        assertTrue(source instanceof HBaseDynamicTableSource);
+        assertThat(source).isInstanceOf(HBaseDynamicTableSource.class);
         HBaseDynamicTableSource hbaseSource = (HBaseDynamicTableSource) source;
 
         int[][] lookupKey = {{0}};
         LookupTableSource.LookupRuntimeProvider lookupProvider =
                 hbaseSource.getLookupRuntimeProvider(new LookupRuntimeProviderContext(lookupKey));
-        assertTrue(lookupProvider instanceof AsyncLookupFunctionProvider);
+        assertThat(lookupProvider).isInstanceOf(AsyncLookupFunctionProvider.class);
 
         AsyncLookupFunction asyncTableFunction =
                 ((AsyncLookupFunctionProvider) lookupProvider).createAsyncLookupFunction();
-        assertTrue(asyncTableFunction instanceof HBaseRowDataAsyncLookupFunction);
-        assertEquals(
-                "testHBastTable",
-                ((HBaseRowDataAsyncLookupFunction) asyncTableFunction).getHTableName());
+        assertThat(asyncTableFunction).isInstanceOf(HBaseRowDataAsyncLookupFunction.class);
+        assertThat(((HBaseRowDataAsyncLookupFunction) asyncTableFunction).getHTableName())
+                .isEqualTo("testHBastTable");
     }
 
     @Test
-    public void testDisabledBufferFlushOptions() {
+    void testDisabledBufferFlushOptions() {
         Map<String, String> options = getAllOptions();
         options.put("sink.buffer-flush.max-size", "0");
         options.put("sink.buffer-flush.max-rows", "0");
@@ -330,7 +307,7 @@ public class HBaseDynamicTableFactoryTest {
                         .setBufferFlushMaxSizeInBytes(0)
                         .build();
         HBaseWriteOptions actual = ((HBaseDynamicTableSink) sink).getWriteOptions();
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -342,88 +319,49 @@ public class HBaseDynamicTableFactoryTest {
                         Column.physical(ROWKEY, STRING()),
                         Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))));
 
-        try {
-            createTableSource(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e, "Unsupported options:\n\nsink.unknown.key")
-                            .isPresent());
-        }
-
-        try {
-            createTableSink(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e, "Unsupported options:\n\nsink.unknown.key")
-                            .isPresent());
-        }
+        assertThatThrownBy(() -> createTableSource(schema, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "Unsupported options:\n\nsink.unknown.key"));
+        assertThatThrownBy(() -> createTableSink(schema, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "Unsupported options:\n\nsink.unknown.key"));
     }
 
     @Test
     public void testTypeWithUnsupportedPrecision() {
         Map<String, String> options = getAllOptions();
         // test unsupported timestamp precision
-        ResolvedSchema schema =
+        ResolvedSchema wrongTs =
                 ResolvedSchema.of(
                         Column.physical(ROWKEY, STRING()),
                         Column.physical(
                                 FAMILY1, ROW(FIELD(COL1, TIMESTAMP(6)), FIELD(COL2, INT()))));
-        try {
-            createTableSource(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e,
-                                    "The precision 6 of TIMESTAMP type is out of the range [0, 3]"
-                                            + " supported by HBase connector")
-                            .isPresent());
-        }
 
-        try {
-            createTableSink(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e,
-                                    "The precision 6 of TIMESTAMP type is out of the range [0, 3]"
-                                            + " supported by HBase connector")
-                            .isPresent());
-        }
+        assertThatThrownBy(() -> createTableSource(wrongTs, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "The precision 6 of TIMESTAMP type is out of the range [0, 3] supported by HBase connector"));
+        assertThatThrownBy(() -> createTableSink(wrongTs, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "The precision 6 of TIMESTAMP type is out of the range [0, 3] supported by HBase connector"));
+
         // test unsupported time precision
-        schema =
+        ResolvedSchema wrongTimeSchema =
                 ResolvedSchema.of(
                         Column.physical(ROWKEY, STRING()),
                         Column.physical(FAMILY1, ROW(FIELD(COL1, TIME(6)), FIELD(COL2, INT()))));
 
-        try {
-            createTableSource(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e,
-                                    "The precision 6 of TIME type is out of the range [0, 3]"
-                                            + " supported by HBase connector")
-                            .isPresent());
-        }
-
-        try {
-            createTableSink(schema, options);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e,
-                                    "The precision 6 of TIME type is out of the range [0, 3]"
-                                            + " supported by HBase connector")
-                            .isPresent());
-        }
+        assertThatThrownBy(() -> createTableSource(wrongTimeSchema, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "The precision 6 of TIME type is out of the range [0, 3] supported by HBase connector"));
+        assertThatThrownBy(() -> createTableSink(wrongTimeSchema, options))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                "The precision 6 of TIME type is out of the range [0, 3] supported by HBase connector"));
     }
 
     private Map<String, String> getAllOptions() {

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/source/HBaseRowDataAsyncLookupFunctionTest.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/source/HBaseRowDataAsyncLookupFunctionTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.connector.source.lookup.LookupOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,13 +40,12 @@ import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test suite for {@link HBaseRowDataAsyncLookupFunction}. */
-public class HBaseRowDataAsyncLookupFunctionTest extends HBaseTestBase {
+class HBaseRowDataAsyncLookupFunctionTest extends HBaseTestBase {
     @Test
-    public void testEval() throws Exception {
+    void testEval() throws Exception {
         HBaseRowDataAsyncLookupFunction lookupFunction = buildRowDataAsyncLookupFunction();
 
         lookupFunction.open(null);
@@ -69,21 +68,21 @@ public class HBaseRowDataAsyncLookupFunctionTest extends HBaseTestBase {
                     });
         }
         // this verifies lookup calls are async
-        assertTrue(result.size() < rowkeys.length);
+        assertThat(result.size()).isLessThan(rowkeys.length);
         latch.await();
         lookupFunction.close();
-        List<String> sortResult = new ArrayList<>(result);
-        Collections.sort(sortResult);
-        List<String> expected = new ArrayList<>();
-        expected.add("12: null");
-        expected.add("12: null");
-        expected.add("1: +I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))");
-        expected.add("1: +I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))");
-        expected.add("2: +I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))");
-        expected.add("3: +I(3,+I(30),+I(Hello-3,300),+I(3.03,false,Welt-3))");
-        expected.add("3: +I(3,+I(30),+I(Hello-3,300),+I(3.03,false,Welt-3))");
-        expected.add("4: +I(4,+I(40),+I(null,400),+I(4.04,true,Welt-4))");
-        assertEquals(expected, sortResult);
+        Collections.sort(result);
+
+        assertThat(result)
+                .containsExactly(
+                        "12: null",
+                        "12: null",
+                        "1: +I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))",
+                        "1: +I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))",
+                        "2: +I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))",
+                        "3: +I(3,+I(30),+I(Hello-3,300),+I(3.03,false,Welt-3))",
+                        "3: +I(3,+I(30),+I(Hello-3,300),+I(3.03,false,Welt-3))",
+                        "4: +I(4,+I(40),+I(null,400),+I(4.04,true,Welt-4))");
     }
 
     private HBaseRowDataAsyncLookupFunction buildRowDataAsyncLookupFunction() {

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -82,12 +82,12 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected EnvironmentSettings streamSettings;
     protected EnvironmentSettings batchSettings;
 
-    @BeforeClass
+    @BeforeAll
     public static void activateHBaseCluster() throws IOException {
         prepareTables();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         this.streamSettings = EnvironmentSettings.inStreamingMode();
         this.batchSettings = EnvironmentSettings.inBatchMode();


### PR DESCRIPTION
Update the existing tests to JUnit5.

Except `HBaseTablePlanTest`, which is based on `TableTestBase` from the core Flink repo, that is still on JUnit4.