### PR TITLE
[FLINK-30460] Support the writable metadata ttl.

### DIFF
--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -99,6 +99,12 @@ ON myTopic.key = hTable.rowkey;
       <td>HBase记录的时间戳。</td>
       <td><code>W</code></td>
     </tr>
+    <tr>
+      <td><code>ttl</code></td>
+      <td><code>BIGINT NOT NULL</code></td>
+      <td>HBase记录的生存时间（毫秒）。</td>
+      <td><code>W</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -101,6 +101,12 @@ Read-only columns must be declared `VIRTUAL` to exclude them during an `INSERT I
       <td>Timestamp for the HBase mutation.</td>
       <td><code>W</code></td>
     </tr>
+    <tr>
+      <td><code>ttl</code></td>
+      <td><code>BIGINT NOT NULL</code></td>
+      <td>Time-to-live for the HBase mutation, in milliseconds.</td>
+      <td><code>W</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -45,6 +45,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
     protected static final String TEST_TABLE_5 = "testTable5";
+    protected static final String TEST_TABLE_6 = "testTable6";
     protected static final String TEST_EMPTY_TABLE = "testEmptyTable";
     protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
@@ -98,6 +99,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable3();
         createHBaseTable4();
         createHBaseTable5();
+        createHBaseTable6();
         createEmptyHBaseTable();
     }
 
@@ -250,6 +252,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         // create a table
         byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
         TableName tableName = TableName.valueOf(TEST_TABLE_5);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createHBaseTable6() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_TABLE_6);
         createTable(tableName, families, SPLIT_KEYS);
     }
 

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -60,6 +60,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -449,6 +450,74 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         String expected = "+I[1, 1]\n+I[2, 20]\n+I[3, 3]\n";
 
         TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @Test
+    public void testTableSinkWithTTLMetadata() throws Exception {
+        StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+
+        tEnv.executeSql(
+                "CREATE TABLE hTableForSink ("
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
+                        + " family1 ROW<col1 INT>,"
+                        + " ttl BIGINT NOT NULL METADATA FROM 'ttl'"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-2.2',"
+                        + " 'table-name' = '"
+                        + TEST_TABLE_6
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        String insert =
+                "INSERT INTO hTableForSink VALUES"
+                        + "(1, ROW(1), 2000),"
+                        + "(2, ROW(2), 9000),"
+                        + "(3, ROW(3), 5000)";
+        tEnv.executeSql(insert).await();
+
+        tEnv.executeSql(
+                "CREATE TABLE hTableForQuery ("
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
+                        + " family1 ROW<col1 INT>"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-2.2',"
+                        + " 'table-name' = '"
+                        + TEST_TABLE_6
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+        String query = "SELECT rowkey, family1.col1 FROM hTableForQuery";
+
+        TableResult firstResult = tEnv.executeSql(query);
+        List<Row> firstResults = CollectionUtil.iteratorToList(firstResult.collect());
+        String firstExpected = "+I[1, 1]\n+I[2, 2]\n+I[3, 3]\n";
+        TestBaseUtils.compareResultAsText(firstResults, firstExpected);
+
+        TimeUnit.SECONDS.sleep(3);
+
+        TableResult secondResult = tEnv.executeSql(query);
+        List<Row> secondResults = CollectionUtil.iteratorToList(secondResult.collect());
+        String secondExpected = "+I[2, 2]\n+I[3, 3]\n";
+        TestBaseUtils.compareResultAsText(secondResults, secondExpected);
+
+        TimeUnit.SECONDS.sleep(3);
+
+        TableResult thirdResult = tEnv.executeSql(query);
+        List<Row> thirdResults = CollectionUtil.iteratorToList(thirdResult.collect());
+        String thirdExpected = "+I[2, 2]";
+        TestBaseUtils.compareResultAsText(thirdResults, thirdExpected);
+
+        TimeUnit.SECONDS.sleep(4);
+
+        TableResult lastResult = tEnv.executeSql(query);
+        List<Row> lastResults = CollectionUtil.iteratorToList(lastResult.collect());
+        assertThat(lastResults).isEmpty();
     }
 
     @Test

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -45,6 +45,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
     protected static final String TEST_TABLE_3 = "testTable3";
     protected static final String TEST_TABLE_4 = "testTable4";
     protected static final String TEST_TABLE_5 = "testTable5";
+    protected static final String TEST_TABLE_6 = "testTable6";
     protected static final String TEST_EMPTY_TABLE = "testEmptyTable";
     protected static final String TEST_NOT_EXISTS_TABLE = "notExistsTable";
 
@@ -98,6 +99,7 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         createHBaseTable3();
         createHBaseTable4();
         createHBaseTable5();
+        createHBaseTable6();
         createEmptyHBaseTable();
     }
 
@@ -250,6 +252,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         // create a table
         byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
         TableName tableName = TableName.valueOf(TEST_TABLE_5);
+        createTable(tableName, families, SPLIT_KEYS);
+    }
+
+    private static void createHBaseTable6() {
+        // create a table
+        byte[][] families = new byte[][] {Bytes.toBytes(FAMILY1)};
+        TableName tableName = TableName.valueOf(TEST_TABLE_6);
         createTable(tableName, families, SPLIT_KEYS);
     }
 

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -135,7 +135,7 @@ public class HBaseSerde {
      *
      * @return The appropriate instance of Put for this use case.
      */
-    public @Nullable Put createPutMutation(RowData row, long timestamp) {
+    public @Nullable Put createPutMutation(RowData row, long timestamp, @Nullable Long timeToLive) {
         checkArgument(keyEncoder != null, "row key is not set.");
         byte[] rowkey = keyEncoder.encode(row, rowkeyIndex);
         if (rowkey.length == 0) {
@@ -144,6 +144,9 @@ public class HBaseSerde {
         }
         // upsert
         Put put = new Put(rowkey, timestamp);
+        if (timeToLive != null) {
+            put.setTTL(timeToLive);
+        }
         for (int i = 0; i < fieldLength; i++) {
             if (i != rowkeyIndex) {
                 int f = i > rowkeyIndex ? i - 1 : i;

--- a/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
+++ b/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
@@ -106,7 +106,7 @@ class HBaseSerdeTest {
     @Test
     public void writeIgnoreNullValueTest() {
         HBaseSerde serde = createHBaseSerde(false);
-        Put m1 = serde.createPutMutation(prepareRowData(), HConstants.LATEST_TIMESTAMP);
+        Put m1 = serde.createPutMutation(prepareRowData(), HConstants.LATEST_TIMESTAMP, null);
         assert m1 != null;
         assertThat(m1.getRow()).isNotEmpty();
         assertThat(m1.get(FAMILY1.getBytes(), F1COL1.getBytes())).isNotEmpty();
@@ -119,7 +119,7 @@ class HBaseSerdeTest {
         HBaseSerde writeIgnoreNullValueSerde = createHBaseSerde(true);
         Put m2 =
                 writeIgnoreNullValueSerde.createPutMutation(
-                        prepareRowData(), HConstants.LATEST_TIMESTAMP);
+                        prepareRowData(), HConstants.LATEST_TIMESTAMP, null);
         assert m2 != null;
         assertThat(m2.getRow()).isNotEmpty();
         assertThat(m2.get(FAMILY1.getBytes(), F1COL1.getBytes())).isEmpty();


### PR DESCRIPTION
## What is the purpose of the change

Support the hbase writable metadata ttl, allow user to set the cell ttl.

## Brief change log

  - *support the writable metadata ttl*

## Verifying this change

This change is already covered by existing tests, such as
  - *org.apache.flink.connector.hbase1.HBaseConnectorITCase#testTableSinkWithTTLMetadata*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testTableSinkWithTTLMetadata*