### PR TITLE
[FLINK-33971]Specifies whether to use HBase table that supports dynamic columns.

### DIFF
--- a/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
+++ b/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.DYNAMIC_TABLE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_ASYNC;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_CACHE_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_CACHE_TTL;
@@ -148,6 +149,7 @@ public class HBase1DynamicTableFactory
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> set = new HashSet<>();
         set.add(ZOOKEEPER_ZNODE_PARENT);
+        set.add(DYNAMIC_TABLE);
         set.add(NULL_STRING_LITERAL);
         set.add(SINK_BUFFER_FLUSH_MAX_SIZE);
         set.add(SINK_BUFFER_FLUSH_MAX_ROWS);

--- a/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
+++ b/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
@@ -79,7 +79,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink, SupportsWritingM
                                 physicalDataType,
                                 metadataKeys,
                                 nullStringLiteral,
-                                writeOptions.isIgnoreNullValue()),
+                                writeOptions.isIgnoreNullValue(),
+                                writeOptions.isDynamicTable()),
                         writeOptions.getBufferFlushMaxSizeInBytes(),
                         writeOptions.getBufferFlushMaxRows(),
                         writeOptions.getBufferFlushIntervalMillis());

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -676,6 +676,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
                                 tableSchema.convertToDataType(),
                                 Collections.emptyList(),
                                 "null",
+                                false,
                                 false),
                         2 * 1024 * 1024,
                         1000,

--- a/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -318,6 +318,58 @@ class HBaseConnectorITCase extends HBaseTestBase {
     }
 
     @Test
+    void testTableSinkWithWithDynamicTableAndTTLMetadata() throws Exception {
+        StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+
+        tEnv.executeSql(
+                "CREATE TABLE hTableForSink ("
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
+                        + " family1 ROW<col1 STRING, col2 INT>,"
+                        + " ttl BIGINT NOT NULL METADATA FROM 'ttl'"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-1.4',"
+                        + " 'table-name' = '"
+                        + TEST_TABLE_6
+                        + "',"
+                        + " 'dynamic.table' = 'true',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        String insert = "INSERT INTO hTableForSink VALUES" + "(1, ROW('20240108',1),3000)";
+        tEnv.executeSql(insert).await();
+
+        tEnv.executeSql(
+                "CREATE TABLE hTableForQuery ("
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
+                        + " family1 ROW<`20240108` int>"
+                        + ") WITH ("
+                        + " 'connector' = 'hbase-1.4',"
+                        + " 'table-name' = '"
+                        + TEST_TABLE_6
+                        + "',"
+                        + " 'zookeeper.quorum' = '"
+                        + getZookeeperQuorum()
+                        + "'"
+                        + ")");
+
+        String query = "SELECT rowkey,family1.`20240108` FROM hTableForQuery";
+
+        TableResult firstResult = tEnv.executeSql(query);
+        List<Row> firstResults = CollectionUtil.iteratorToList(firstResult.collect());
+        String firstExpected = "+I[1, 1]\n";
+        TestBaseUtils.compareResultAsText(firstResults, firstExpected);
+
+        TimeUnit.SECONDS.sleep(5);
+
+        TableResult lastResult = tEnv.executeSql(query);
+        List<Row> lastResults = CollectionUtil.iteratorToList(lastResult.collect());
+        assertThat(lastResults).isEmpty();
+    }
+
+    @Test
     void testTableSinkWithChangelog() throws Exception {
         StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);

--- a/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
+++ b/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.DYNAMIC_TABLE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_ASYNC;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_CACHE_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.LOOKUP_CACHE_TTL;
@@ -121,6 +122,7 @@ public class HBase2DynamicTableFactory
         validatePrimaryKey(context.getPhysicalRowDataType(), context.getPrimaryKeyIndexes());
 
         String tableName = tableOptions.get(TABLE_NAME);
+        boolean dynamicTable = tableOptions.get(DYNAMIC_TABLE);
         Configuration hbaseConf = getHBaseConfiguration(tableOptions);
         HBaseWriteOptions hBaseWriteOptions = getHBaseWriteOptions(tableOptions);
         String nullStringLiteral = tableOptions.get(NULL_STRING_LITERAL);
@@ -151,6 +153,7 @@ public class HBase2DynamicTableFactory
         set.add(ZOOKEEPER_ZNODE_PARENT);
         set.add(ZOOKEEPER_QUORUM);
         set.add(NULL_STRING_LITERAL);
+        set.add(DYNAMIC_TABLE);
         set.add(SINK_BUFFER_FLUSH_MAX_SIZE);
         set.add(SINK_BUFFER_FLUSH_MAX_ROWS);
         set.add(SINK_BUFFER_FLUSH_INTERVAL);

--- a/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
+++ b/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
@@ -79,7 +79,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink, SupportsWritingM
                                 physicalDataType,
                                 metadataKeys,
                                 nullStringLiteral,
-                                writeOptions.isIgnoreNullValue()),
+                                writeOptions.isIgnoreNullValue(),
+                                writeOptions.isDynamicTable()),
                         writeOptions.getBufferFlushMaxSizeInBytes(),
                         writeOptions.getBufferFlushMaxRows(),
                         writeOptions.getBufferFlushIntervalMillis());

--- a/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -649,6 +649,7 @@ class HBaseConnectorITCase extends HBaseTestBase {
                                 tableSchema.convertToDataType(),
                                 Collections.emptyList(),
                                 "null",
+                                false,
                                 false),
                         2 * 1024 * 1024,
                         1000,

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
@@ -36,18 +36,21 @@ public class HBaseWriteOptions implements Serializable {
     private final long bufferFlushIntervalMillis;
     private final boolean ignoreNullValue;
     private final Integer parallelism;
+    private final boolean dynamicTable;
 
     private HBaseWriteOptions(
             long bufferFlushMaxSizeInBytes,
             long bufferFlushMaxMutations,
             long bufferFlushIntervalMillis,
             boolean ignoreNullValue,
-            Integer parallelism) {
+            Integer parallelism,
+            boolean dynamicTable) {
         this.bufferFlushMaxSizeInBytes = bufferFlushMaxSizeInBytes;
         this.bufferFlushMaxRows = bufferFlushMaxMutations;
         this.bufferFlushIntervalMillis = bufferFlushIntervalMillis;
         this.ignoreNullValue = ignoreNullValue;
         this.parallelism = parallelism;
+        this.dynamicTable = dynamicTable;
     }
 
     public long getBufferFlushMaxSizeInBytes() {
@@ -70,6 +73,10 @@ public class HBaseWriteOptions implements Serializable {
         return parallelism;
     }
 
+    public boolean isDynamicTable() {
+        return dynamicTable;
+    }
+
     @Override
     public String toString() {
         return "HBaseWriteOptions{"
@@ -83,6 +90,8 @@ public class HBaseWriteOptions implements Serializable {
                 + ignoreNullValue
                 + ", parallelism="
                 + parallelism
+                + ", dynamicTable="
+                + dynamicTable
                 + '}';
     }
 
@@ -124,6 +133,7 @@ public class HBaseWriteOptions implements Serializable {
         private long bufferFlushIntervalMillis = 0;
         private boolean ignoreNullValue;
         private Integer parallelism;
+        private boolean dynamicTable;
 
         /**
          * Optional. Sets when to flush a buffered request based on the memory size of rows
@@ -170,6 +180,12 @@ public class HBaseWriteOptions implements Serializable {
             return this;
         }
 
+        /** Optional. Sets whether to use dynamic table. Defaults to not set. */
+        public Builder setDynamicTable(boolean dynamicTable) {
+            this.dynamicTable = dynamicTable;
+            return this;
+        }
+
         /** Creates a new instance of {@link HBaseWriteOptions}. */
         public HBaseWriteOptions build() {
             return new HBaseWriteOptions(
@@ -177,7 +193,8 @@ public class HBaseWriteOptions implements Serializable {
                     bufferFlushMaxRows,
                     bufferFlushIntervalMillis,
                     ignoreNullValue,
-                    parallelism);
+                    parallelism,
+                    dynamicTable);
         }
     }
 }

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptions.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptions.java
@@ -60,6 +60,12 @@ public class HBaseConnectorOptions {
                             "Representation for null values for string fields. HBase source and "
                                     + "sink encodes/decodes empty bytes as null values for all types except string type.");
 
+    public static final ConfigOption<Boolean> DYNAMIC_TABLE =
+            ConfigOptions.key("dynamic.table")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to use dynamic table.");
+
     public static final ConfigOption<MemorySize> SINK_BUFFER_FLUSH_MAX_SIZE =
             ConfigOptions.key("sink.buffer-flush.max-size")
                     .memoryType()

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptionsUtil.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptionsUtil.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hbase.HConstants;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.DYNAMIC_TABLE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_SIZE;
@@ -92,6 +93,7 @@ public class HBaseConnectorOptionsUtil {
                 tableOptions.get(SINK_BUFFER_FLUSH_MAX_SIZE).getBytes());
         builder.setIgnoreNullValue(tableOptions.get(SINK_IGNORE_NULL_VALUE));
         builder.setParallelism(tableOptions.getOptional(SINK_PARALLELISM).orElse(null));
+        builder.setDynamicTable(tableOptions.get(DYNAMIC_TABLE));
         return builder.build();
     }
 

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -190,7 +190,7 @@ public class HBaseSerde {
      *
      * @return The appropriate instance of Put for this use case.
      */
-    public Put createDynamicColumnPutMutation(
+    public @Nullable Put createDynamicColumnPutMutation(
             RowData row, Long timestamp, @Nullable Long timeToLive) {
         checkArgument(keyEncoder != null, "row key is not set.");
         byte[] rowkey = keyEncoder.encode(row, rowkeyIndex);
@@ -200,6 +200,9 @@ public class HBaseSerde {
         }
         // upsert
         Put put = new Put(rowkey);
+        if (timeToLive != null) {
+            put.setTTL(timeToLive);
+        }
         for (int i = 0; i < fieldLength; i++) {
             if (i != rowkeyIndex) {
                 int f = i > rowkeyIndex ? i - 1 : i;

--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -59,6 +59,8 @@ public class HBaseSerde {
 
     private final boolean writeIgnoreNullValue;
 
+    private boolean dynamicTable;
+
     // row key index in output row
     private final int rowkeyIndex;
 
@@ -79,15 +81,17 @@ public class HBaseSerde {
     private final GenericRowData rowWithRowKey;
 
     public HBaseSerde(HBaseTableSchema hbaseSchema, final String nullStringLiteral) {
-        this(hbaseSchema, nullStringLiteral, false);
+        this(hbaseSchema, nullStringLiteral, false, false);
     }
 
     public HBaseSerde(
             HBaseTableSchema hbaseSchema,
             final String nullStringLiteral,
-            boolean writeIgnoreNullValue) {
+            boolean writeIgnoreNullValue,
+            boolean dynamicTable) {
         this.families = hbaseSchema.getFamilyKeys();
         this.rowkeyIndex = hbaseSchema.getRowKeyIndex();
+        this.dynamicTable = dynamicTable;
         LogicalType rowkeyType =
                 hbaseSchema.getRowKeyDataType().map(DataType::getLogicalType).orElse(null);
 
@@ -112,20 +116,31 @@ public class HBaseSerde {
         this.qualifierEncoders = new FieldEncoder[families.length][];
         this.qualifierDecoders = new FieldDecoder[families.length][];
         String[] familyNames = hbaseSchema.getFamilyNames();
-        for (int f = 0; f < families.length; f++) {
-            this.qualifiers[f] = hbaseSchema.getQualifierKeys(familyNames[f]);
-            DataType[] dataTypes = hbaseSchema.getQualifierDataTypes(familyNames[f]);
-            this.qualifierEncoders[f] =
-                    Arrays.stream(dataTypes)
-                            .map(DataType::getLogicalType)
-                            .map(t -> createNullableFieldEncoder(t, nullStringBytes))
-                            .toArray(FieldEncoder[]::new);
-            this.qualifierDecoders[f] =
-                    Arrays.stream(dataTypes)
-                            .map(DataType::getLogicalType)
-                            .map(t -> createNullableFieldDecoder(t, nullStringBytes))
-                            .toArray(FieldDecoder[]::new);
-            this.reusedFamilyRows[f] = new GenericRowData(dataTypes.length);
+        if (dynamicTable) {
+            for (int f = 0; f < families.length; f++) {
+                DataType[] dataTypes = hbaseSchema.getQualifierDataTypes(familyNames[f]);
+                this.qualifierEncoders[f] =
+                        Arrays.stream(dataTypes)
+                                .map(DataType::getLogicalType)
+                                .map(t -> createNullableFieldEncoder(t, nullStringBytes))
+                                .toArray(FieldEncoder[]::new);
+            }
+        } else {
+            for (int f = 0; f < families.length; f++) {
+                this.qualifiers[f] = hbaseSchema.getQualifierKeys(familyNames[f]);
+                DataType[] dataTypes = hbaseSchema.getQualifierDataTypes(familyNames[f]);
+                this.qualifierEncoders[f] =
+                        Arrays.stream(dataTypes)
+                                .map(DataType::getLogicalType)
+                                .map(t -> createNullableFieldEncoder(t, nullStringBytes))
+                                .toArray(FieldEncoder[]::new);
+                this.qualifierDecoders[f] =
+                        Arrays.stream(dataTypes)
+                                .map(DataType::getLogicalType)
+                                .map(t -> createNullableFieldDecoder(t, nullStringBytes))
+                                .toArray(FieldDecoder[]::new);
+                this.reusedFamilyRows[f] = new GenericRowData(dataTypes.length);
+            }
         }
         this.rowWithRowKey = new GenericRowData(1);
     }
@@ -171,6 +186,35 @@ public class HBaseSerde {
     }
 
     /**
+     * Returns an instance of Put that writes record to HBase table.
+     *
+     * @return The appropriate instance of Put for this use case.
+     */
+    public Put createDynamicColumnPutMutation(
+            RowData row, Long timestamp, @Nullable Long timeToLive) {
+        checkArgument(keyEncoder != null, "row key is not set.");
+        byte[] rowkey = keyEncoder.encode(row, rowkeyIndex);
+        if (rowkey.length == 0) {
+            // drop dirty records, rowkey shouldn't be zero length
+            return null;
+        }
+        // upsert
+        Put put = new Put(rowkey);
+        for (int i = 0; i < fieldLength; i++) {
+            if (i != rowkeyIndex) {
+                int f = i > rowkeyIndex ? i - 1 : i;
+                // get family key
+                byte[] familyKey = families[f];
+                RowData familyRow = row.getRow(i, 2);
+                byte[] qualifier = qualifierEncoders[f][0].encode(familyRow, 0);
+                byte[] value = qualifierEncoders[f][1].encode(familyRow, 1);
+                put.addColumn(familyKey, qualifier, value);
+            }
+        }
+        return put;
+    }
+
+    /**
      * Returns an instance of Delete that remove record from HBase table.
      *
      * @return The appropriate instance of Delete for this use case.
@@ -200,12 +244,42 @@ public class HBaseSerde {
     }
 
     /**
+     * Returns an instance of Delete that remove record from HBase table.
+     *
+     * @return The appropriate instance of Delete for this use case.
+     */
+    public Delete createDynamicColumnDeleteMutation(RowData row, Long timestamp) {
+        checkArgument(keyEncoder != null, "row key is not set.");
+        byte[] rowkey = keyEncoder.encode(row, rowkeyIndex);
+        if (rowkey.length == 0) {
+            // drop dirty records, rowkey shouldn't be zero length
+            return null;
+        }
+        // delete
+        Delete delete = new Delete(rowkey);
+        for (int i = 0; i < fieldLength; i++) {
+            if (i != rowkeyIndex) {
+                int f = i > rowkeyIndex ? i - 1 : i;
+                // get family key
+                byte[] familyKey = families[f];
+                RowData familyRow = row.getRow(i, 2);
+                byte[] qualifier = qualifierEncoders[f][0].encode(familyRow, 0);
+                delete.addColumn(familyKey, qualifier);
+            }
+        }
+        return delete;
+    }
+
+    /**
      * Returns an instance of Scan that retrieves the required subset of records from the HBase
      * table.
      *
      * @return The appropriate instance of Scan for this use case.
      */
     public Scan createScan() {
+        if (dynamicTable) {
+            throw new UnsupportedOperationException();
+        }
         Scan scan = new Scan();
         for (int f = 0; f < families.length; f++) {
             byte[] family = families[f];
@@ -223,6 +297,9 @@ public class HBaseSerde {
      * @return The appropriate instance of Get for this use case.
      */
     public Get createGet(Object rowKey) {
+        if (dynamicTable) {
+            throw new UnsupportedOperationException();
+        }
         checkArgument(keyEncoder != null, "row key is not set.");
         rowWithRowKey.setField(0, rowKey);
         byte[] rowkey = keyEncoder.encode(rowWithRowKey, 0);
@@ -267,6 +344,9 @@ public class HBaseSerde {
 
     private RowData convertToRow(
             Result result, GenericRowData resultRow, GenericRowData[] familyRows) {
+        if (dynamicTable) {
+            throw new UnsupportedOperationException();
+        }
         for (int i = 0; i < fieldLength; i++) {
             if (rowkeyIndex == i) {
                 assert keyDecoder != null;
@@ -297,6 +377,9 @@ public class HBaseSerde {
      */
     @Deprecated
     public RowData convertToRow(Result result) {
+        if (dynamicTable) {
+            throw new UnsupportedOperationException();
+        }
         for (int i = 0; i < fieldLength; i++) {
             if (rowkeyIndex == i) {
                 assert keyDecoder != null;

--- a/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
+++ b/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
@@ -81,27 +81,6 @@ class HBaseSerdeTest {
                         "+I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))");
     }
 
-    //    @Test
-    //    void convertToNewRowTestDynamicTable() {
-    //        DynamicHBaseSerde serde = createDynamicHBaseSerde(false);
-    //        List<List<Cell>> cellsList = prepareCells();
-    //        List<RowData> resultRowDatas = new ArrayList<>();
-    //        List<String> resultRowDataStr = new ArrayList<>();
-    //        for (List<Cell> cells : cellsList) {
-    //            RowData row = serde.
-    //            resultRowDatas.add(row);
-    //            resultRowDataStr.add(row.toString());
-    //        }
-    //
-    //        assertThat(resultRowDatas.get(0))
-    //                .as("RowData should not be reused")
-    //                .isNotSameAs(resultRowDatas.get(1));
-    //        assertThat(resultRowDataStr)
-    //                .containsExactly(
-    //                        "+I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))",
-    //                        "+I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))");
-    //    }
-
     @Test
     void convertToReusedRowTest() {
         HBaseSerde serde = createHBaseSerde(false);
@@ -166,16 +145,8 @@ class HBaseSerdeTest {
         return HBaseTableSchema.fromDataType(dataType);
     }
 
-    private HBaseTableSchema createDynamicHBaseTableSchema() {
-        DataType dataType =
-                ROW(
-                        FIELD(ROW_KEY, INT()),
-                        FIELD(FAMILY2, ROW(FIELD(F2COL1, STRING()), FIELD(F2COL2, BIGINT()))));
-        return HBaseTableSchema.fromDataType(dataType);
-    }
-
     private HBaseSerde createHBaseSerde(boolean writeIgnoreNullValue) {
-        return new HBaseSerde(createDynamicHBaseTableSchema(), "null", writeIgnoreNullValue, true);
+        return new HBaseSerde(createHBaseTableSchema(), "null", writeIgnoreNullValue, false);
     }
 
     private List<List<Cell>> prepareCells() {

--- a/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
+++ b/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/util/HBaseSerdeTest.java
@@ -81,6 +81,27 @@ class HBaseSerdeTest {
                         "+I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))");
     }
 
+    //    @Test
+    //    void convertToNewRowTestDynamicTable() {
+    //        DynamicHBaseSerde serde = createDynamicHBaseSerde(false);
+    //        List<List<Cell>> cellsList = prepareCells();
+    //        List<RowData> resultRowDatas = new ArrayList<>();
+    //        List<String> resultRowDataStr = new ArrayList<>();
+    //        for (List<Cell> cells : cellsList) {
+    //            RowData row = serde.
+    //            resultRowDatas.add(row);
+    //            resultRowDataStr.add(row.toString());
+    //        }
+    //
+    //        assertThat(resultRowDatas.get(0))
+    //                .as("RowData should not be reused")
+    //                .isNotSameAs(resultRowDatas.get(1));
+    //        assertThat(resultRowDataStr)
+    //                .containsExactly(
+    //                        "+I(1,+I(10),+I(Hello-1,100),+I(1.01,false,Welt-1))",
+    //                        "+I(2,+I(20),+I(Hello-2,200),+I(2.02,true,Welt-2))");
+    //    }
+
     @Test
     void convertToReusedRowTest() {
         HBaseSerde serde = createHBaseSerde(false);
@@ -145,8 +166,16 @@ class HBaseSerdeTest {
         return HBaseTableSchema.fromDataType(dataType);
     }
 
+    private HBaseTableSchema createDynamicHBaseTableSchema() {
+        DataType dataType =
+                ROW(
+                        FIELD(ROW_KEY, INT()),
+                        FIELD(FAMILY2, ROW(FIELD(F2COL1, STRING()), FIELD(F2COL2, BIGINT()))));
+        return HBaseTableSchema.fromDataType(dataType);
+    }
+
     private HBaseSerde createHBaseSerde(boolean writeIgnoreNullValue) {
-        return new HBaseSerde(createHBaseTableSchema(), "null", writeIgnoreNullValue);
+        return new HBaseSerde(createDynamicHBaseTableSchema(), "null", writeIgnoreNullValue, true);
     }
 
     private List<List<Cell>> prepareCells() {


### PR DESCRIPTION
Specifies whether to use HBase table that supports dynamic columns.

Refer to the dynamic.table parameter in this document: [https://www.alibabacloud.com/help/en/flink/developer-reference/apsaradb-for-hbase-connector#section-ltp-3fy-9qv](https://www.alibabacloud.com/help/en/flink/developer-reference/apsaradb-for-hbase-connector#section-ltp-3fy-9qv)

Sample code for a result table that supports dynamic columns
```
CREATE TEMPORARY TABLE datagen_source (
  id INT,
  f1hour STRING,
  f1deal BIGINT,
  f2day STRING,
  f2deal BIGINT
) WITH (
  'connector'='datagen'
);

CREATE TEMPORARY TABLE hbase_sink (
  rowkey INT,
  f1 ROW<`hour` STRING, deal BIGINT>,
  f2 ROW<`day` STRING, deal BIGINT>
) WITH (
  'connector'='hbase-2.2',
  'table-name'='<yourTableName>',
  'zookeeper.quorum'='<yourZookeeperQuorum>',
  'dynamic.table'='true'
);

INSERT INTO hbase_sink
SELECT id, ROW(f1hour, f1deal), ROW(f2day, f2deal) FROM datagen_source;
```

If dynamic.table is set to true, HBase table that supports dynamic columns is used.
Two fields must be declared in the rows that correspond to each column family. The value of the first field indicates the dynamic column, and the value of the second field indicates the value of the dynamic column.

For example, the datagen_source table contains a row of data The row of data indicates that the ID of the commodity is 1, the transaction amount of the commodity between 10:00 and 11:00 is 100, and the transaction amount of the commodity on July 26, 2020 is 10000. In this case, a row whose rowkey is 1 is inserted into the HBase table. f1:10 is 100, and f2:2020-7-26 is 10000.