### PR TITLE
[FLINK-35233] Fix lookup cache reuse RowData object problem

### DIFF
--- a/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
+++ b/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/HBaseRowDataLookupFunction.java
@@ -97,7 +97,7 @@ public class HBaseRowDataLookupFunction extends LookupFunction {
                 if (get != null) {
                     Result result = table.get(get);
                     if (!result.isEmpty()) {
-                        return Collections.singletonList(serde.convertToReusedRow(result));
+                        return Collections.singletonList(serde.convertToNewRow(result));
                     }
                 }
                 break;


### PR DESCRIPTION
## What is the purpose of the change

HBase lookup result is wrong when lookup cache is enabled.

## Brief change log

  - *fix lookup cache reuse RowData object problem*

## Verifying this change

This change is already covered by existing tests, such as
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testHBaseLookupTableSource*
  - *org.apache.flink.connector.hbase2.HBaseConnectorITCase#testHBaseAsyncLookupTableSource*