### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string …

### DIFF
--- a/docs/data/hbase.yml
+++ b/docs/data/hbase.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 3.0.0
-flink_compatibility: [1.16, 1.17]
+flink_compatibility: ["1.16", "1.17"]
 variants:
   - maven: flink-connector-hbase-1.4
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-1.4/$full_version/flink-sql-connector-hbase-1.4-$full_version.jar


### PR DESCRIPTION
…to prevent version comparison mismatch

## Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132






## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)