### PR TITLE
[hotfix][docs] Explicitly set connector compatibility as string to prevent version comparison mismatch

### DIFF
--- a/docs/data/hbase.yml
+++ b/docs/data/hbase.yml
@@ -17,6 +17,7 @@
 ################################################################################
 
 version: 4.0.0
+flink_compatibility: ["1.18", "1.19"]
 variants:
   - maven: flink-connector-hbase-2.2
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-2.2/$full_version/flink-sql-connector-hbase-2.2-$full_version.jar


### PR DESCRIPTION
## Purpose of the change

Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132

## Significant changes

No significant change