### PR TITLE
[FLINK-37212] When hbase region move, throw "Unable to load exception received from server: XXX"

### DIFF
--- a/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-sql-connector-hbase-2.2/pom.xml
@@ -139,13 +139,11 @@ under the License.
 								<relocation>
 									<pattern>org.apache.hadoop.hbase</pattern>
 									<shadedPattern>org.apache.flink.hbase.shaded.org.apache.hadoop.hbase</shadedPattern>
-									<!-- HBase client uses shaded KeyValueCodec to encode data and put the class name in
- 										the header of request, the HBase region server can not load the shaded
-										KeyValueCodec class when decode the data, so we exclude them here. -->
+									<!-- Some exceptions also required to keep their original package because the region server sends it that way, and otherwise the client will not recognize it. -->
 									<excludes>
 										<exclude>org.apache.hadoop.hbase.codec.*</exclude>
-										<exclude>org/apache/hadoop/hbase/NotServingRegionException</exclude>
-										<exclude>org/apache/hadoop/hbase/exceptions/RegionMovedException</exclude>
+										<exclude>org.apache.hadoop.hbase.NotServingRegionException</exclude>
+										<exclude>org.apache.hadoop.hbase.exceptions.RegionMovedException</exclude>
 									</excludes>
 								</relocation>
 							</relocations>

--- a/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-sql-connector-hbase-2.2/pom.xml
@@ -144,6 +144,8 @@ under the License.
 										KeyValueCodec class when decode the data, so we exclude them here. -->
 									<excludes>
 										<exclude>org.apache.hadoop.hbase.codec.*</exclude>
+										<exclude>org/apache/hadoop/hbase/NotServingRegionException</exclude>
+										<exclude>org/apache/hadoop/hbase/exceptions/RegionMovedException</exclude>
 									</excludes>
 								</relocation>
 							</relocations>


### PR DESCRIPTION
When Hbase Region move , will cause ' Unable to load exception received from :xxx'. detail can see : [FLINK-37212](https://issues.apache.org/jira/browse/FLINK-37212?jql=project%20%3D%20FLINK%20AND%20issuetype%20%3D%20Bug%20ORDER%20BY%20created%20DESC)