### PR TITLE
[FLINK-38722] Upgrade HBase to 2.6.4

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.20.2 ]
+        flink: [ 1.20.3 ]
         jdk: [ '8, 11, 17' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.20.2,
+          flink: 1.20.3,
           branch: main
         }, {
           flink: 1.19.3,

--- a/flink-connector-hbase-e2e-tests/src/test/java/org/apache/flink/streaming/tests/HBaseITCase.java
+++ b/flink-connector-hbase-e2e-tests/src/test/java/org/apache/flink/streaming/tests/HBaseITCase.java
@@ -51,7 +51,7 @@ import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
 /** End to end HBase connector tests. */
 class HBaseITCase {
 
-    private static final String HBASE_VERSION = "2.6.3";
+    private static final String HBASE_VERSION = "2.6.4";
     private static final String CONNECTOR_VERSION = "hbase-2.6";
     private static final String HBASE_E2E_SQL = "hbase_e2e.sql";
     private static final Path HADOOP_CP = ResourceTestUtils.getResource(".*hadoop.classpath");

--- a/flink-sql-connector-hbase-2.6/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-hbase-2.6/src/main/resources/META-INF/NOTICE
@@ -15,11 +15,11 @@ This project bundles the following dependencies under the Apache Software Licens
  - org.apache.hbase:hbase-protocol:2.6.4
  - org.apache.hbase:hbase-protocol-shaded:2.6.4
  - org.apache.hbase:hbase-logging:2.6.4
- - org.apache.hbase.thirdparty:hbase-unsafe:4.1.11
- - org.apache.hbase.thirdparty:hbase-shaded-protobuf:4.1.11
- - org.apache.hbase.thirdparty:hbase-shaded-miscellaneous:4.1.11
- - org.apache.hbase.thirdparty:hbase-shaded-netty:4.1.11
- - org.apache.hbase.thirdparty:hbase-shaded-gson:4.1.11
+ - org.apache.hbase.thirdparty:hbase-unsafe:4.1.12
+ - org.apache.hbase.thirdparty:hbase-shaded-protobuf:4.1.12
+ - org.apache.hbase.thirdparty:hbase-shaded-miscellaneous:4.1.12
+ - org.apache.hbase.thirdparty:hbase-shaded-netty:4.1.12
+ - org.apache.hbase.thirdparty:hbase-shaded-gson:4.1.12
  - org.apache.zookeeper:zookeeper:3.8.4
  - org.apache.zookeeper:zookeeper-jute:3.8.4
 

--- a/flink-sql-connector-hbase-2.6/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-hbase-2.6/src/main/resources/META-INF/NOTICE
@@ -10,11 +10,11 @@ This project bundles the following dependencies under the Apache Software Licens
  - io.dropwizard.metrics:metrics-core:3.2.6
  - org.apache.commons:commons-crypto:1.1.0
  - org.apache.commons:commons-lang3:3.3.2
- - org.apache.hbase:hbase-client:2.6.3
- - org.apache.hbase:hbase-common:2.6.3
- - org.apache.hbase:hbase-protocol:2.6.3
- - org.apache.hbase:hbase-protocol-shaded:2.6.3
- - org.apache.hbase:hbase-logging:2.6.3
+ - org.apache.hbase:hbase-client:2.6.4
+ - org.apache.hbase:hbase-common:2.6.4
+ - org.apache.hbase:hbase-protocol:2.6.4
+ - org.apache.hbase:hbase-protocol-shaded:2.6.4
+ - org.apache.hbase:hbase-logging:2.6.4
  - org.apache.hbase.thirdparty:hbase-unsafe:4.1.11
  - org.apache.hbase.thirdparty:hbase-shaded-protobuf:4.1.11
  - org.apache.hbase.thirdparty:hbase-shaded-miscellaneous:4.1.11

--- a/flink-sql-connector-hbase-2.6/src/main/resources/hbase-default.xml
+++ b/flink-sql-connector-hbase-2.6/src/main/resources/hbase-default.xml
@@ -1331,7 +1331,7 @@ possible configurations would overwhelm and obscure the important.
 	</property>
 	<property skipInDoc="true">
 		<name>hbase.defaults.for.version</name>
-		<value>2.6.3</value>
+		<value>2.6.4</value>
 		<description>This defaults file was compiled for version ${project.version}. This variable is used
 			to make sure that a user doesn't have an old version of hbase-default.xml on the
 			classpath.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ under the License.
 	</scm>
 
 	<properties>
-		<flink.version>1.20.2</flink.version>
+		<flink.version>1.20.3</flink.version>
 
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala.version>2.12.7</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,13 @@ under the License.
 		<commons.lang3.version>3.3.2</commons.lang3.version>
 		<commons.logging.version>1.1.3</commons.logging.version>
 		<hadoop.version>2.10.2</hadoop.version>
-		<hbase2.version>2.6.3</hbase2.version>
+		<hbase2.version>2.6.4</hbase2.version>
 		<httpclient.version>4.5.13</httpclient.version>
 		<httpcore.version>4.4.14</httpcore.version>
 		<jackson.version>2.13.4.20221013</jackson.version>
 		<jsr305.version>1.3.9</jsr305.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.8.1</junit5.version>
+		<junit5.version>5.14.1</junit5.version>
 		<kryo.verison>2.24.0</kryo.verison>
 		<minikdc.version>3.2.4</minikdc.version>
 		<zookeeper.version>3.8.4</zookeeper.version>
@@ -595,6 +595,13 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.exclude=org.apache.hadoop.hbase.HBaseJupiterExtension
+                        </configurationParameters>
+                    </properties>
+                </configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
- Bump Flink version to 1.20.3
- HBase 2.6.3 no longer exists here since the release of 2.6.4: https://dlcdn.apache.org/hbase/
- Had to exclude [HBaseJupiterExtension](https://github.com/apache/hbase/blob/67f414cfed130bf6325570463ed36ea7d45aebc5/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseJupiterExtension.java#L99) as it caused all tests to fail because some HBase-specific annotations were not present. This extension is used only in the HBase repo that adds timeout to the tests based on annotations, so it's probably safer to disable it altogether.
- JUnit had to be upgraded because `junit.jupiter.extensions.autodetection.exclude` is only available since JUnit 5.12.x